### PR TITLE
Improve shard hash function to use 128 bit mutiply with xor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,11 @@ name = "haphazard"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+std = []
+mutiply_hash = []
+
+default = ["std"]
 
 [dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [features]
 std = []
-mutiply_hash = []
+multiply_hash= []
 
 default = ["std"]
 

--- a/src/deleter.rs
+++ b/src/deleter.rs
@@ -1,3 +1,4 @@
+
 pub trait Reclaim {}
 impl<T> Reclaim for T {}
 
@@ -16,10 +17,11 @@ impl Deleter for unsafe fn(*mut (dyn Reclaim + 'static)) {
 
 pub mod deleters {
     use super::Reclaim;
+    use crate::boxed::Box;
 
     unsafe fn _drop_in_place(ptr: *mut dyn Reclaim) {
         // Safe by the contract on HazPtrObject::retire.
-        unsafe { std::ptr::drop_in_place(ptr) };
+        unsafe { crate::ptr::drop_in_place(ptr) };
     }
 
     /// Always safe to use given requirements on HazPtrObject::retire,

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -48,6 +48,7 @@ pub struct Domain<F> {
     nbulk_reclaims: AtomicUsize,
     count: AtomicIsize,
     shutdown: bool,
+    shard_hash_state: AtomicUsize,
 }
 
 impl Domain<Global> {
@@ -89,6 +90,7 @@ macro_rules! new {
                 nbulk_reclaims: AtomicUsize::new(0),
                 family: PhantomData,
                 shutdown: false,
+                shard_hash_state: AtomicUsize::new(0),
             }
         }
     };
@@ -301,7 +303,7 @@ impl<F> Domain<F> {
         crate::asymmetric_light_barrier();
 
         let retired = Box::into_raw(retired);
-        unsafe { self.untagged[Self::calc_shard(retired)].push(retired, retired) };
+        unsafe { self.untagged[self.calc_shard(retired)].push(retired, retired) };
         self.count.fetch_add(1, Ordering::Release);
 
         self.check_threshold_and_reclaim()
@@ -549,12 +551,25 @@ impl<F> Domain<F> {
     }
 
     #[cfg(not(loom))]
-    fn calc_shard(input: *mut Retired) -> usize {
-        (input as usize >> IGNORED_LOW_BITS) & SHARD_MASK
+    fn calc_shard(&self, input: *mut Retired) -> usize {
+        //XXX: This is not prime when truncated to 32 bits
+        const LARGE_PRIME: usize = 4445950232728569541;
+        let input = input as usize ^ self.shard_hash_state.load(Ordering::Relaxed);
+
+        //XXX: Could be made simpler without the slice stuff using mem::transmute
+        let mul_result = (input as u128 * LARGE_PRIME as u128).to_ne_bytes();
+        let mut hash = [0u8; 8];
+        hash.copy_from_slice(&mul_result[0..8]);
+
+        let mut new_state = [0u8; 8];
+        new_state.copy_from_slice(&mul_result[8..16]);
+
+        self.shard_hash_state.store(u64::from_ne_bytes(new_state) as usize, Ordering::Relaxed);
+        u64::from_ne_bytes(hash) as usize & SHARD_MASK
     }
 
     #[cfg(loom)]
-    fn calc_shard(_input: *mut Retired) -> usize {
+    fn calc_shard(&self, _input: *mut Retired) -> usize {
         SHARD.fetch_add(1, Ordering::Relaxed) & SHARD_MASK
     }
 }

--- a/src/holder.rs
+++ b/src/holder.rs
@@ -1,6 +1,5 @@
-use crate::sync::atomic::AtomicPtr;
+use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::{Domain, HazPtrObject, HazPtrRecord};
-use std::sync::atomic::Ordering;
 
 pub struct HazardPointer<'domain, F> {
     hazard: &'domain HazPtrRecord,
@@ -80,7 +79,7 @@ impl<'domain, F> HazardPointer<'domain, F> {
             Err(ptr2)
         } else {
             // All good -- protected
-            Ok(std::ptr::NonNull::new(ptr).map(|nn| {
+            Ok(crate::ptr::NonNull::new(ptr).map(|nn| {
                 // Safety: this is safe because:
                 //
                 //  1. Target of ptr1 will not be deallocated for the returned lifetime since

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 #![feature(arbitrary_self_types)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(dead_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 mod deleter;
 mod domain;
@@ -12,7 +16,7 @@ mod sync;
 fn asymmetric_light_barrier() {
     // TODO: if cfg!(linux) {
     // https://github.com/facebook/folly/blob/bd600cd4e88f664f285489c76b6ad835d8367cd2/folly/portability/Asm.h#L28
-    crate::sync::atomic::fence(std::sync::atomic::Ordering::SeqCst);
+    crate::sync::atomic::fence(crate::sync::atomic::Ordering::SeqCst);
 }
 
 enum HeavyBarrierKind {
@@ -22,7 +26,7 @@ enum HeavyBarrierKind {
 fn asymmetric_heavy_barrier(_: HeavyBarrierKind) {
     // TODO: if cfg!(linux) {
     // https://github.com/facebook/folly/blob/bd600cd4e88f664f285489c76b6ad835d8367cd2/folly/synchronization/AsymmetricMemoryBarrier.cpp#L84
-    crate::sync::atomic::fence(std::sync::atomic::Ordering::SeqCst);
+    crate::sync::atomic::fence(crate::sync::atomic::Ordering::SeqCst);
 }
 
 pub use domain::Global;
@@ -31,4 +35,6 @@ pub use deleter::{deleters, Deleter, Reclaim};
 pub use domain::Domain;
 pub use holder::HazardPointer;
 pub use object::{HazPtrObject, HazPtrObjectWrapper};
+
 pub(crate) use record::HazPtrRecord;
+pub(crate) use sync::{ptr, marker, mem, boxed, ops};

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,5 +1,5 @@
 use crate::{Deleter, Domain, Reclaim};
-use std::ops::{Deref, DerefMut};
+use crate::ops::{Deref, DerefMut};
 
 pub trait HazPtrObject<'domain, F: 'static>
 where

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,5 +1,4 @@
-use crate::sync::atomic::AtomicPtr;
-use std::sync::atomic::Ordering;
+use crate::sync::atomic::{AtomicPtr, Ordering};
 
 pub(crate) struct HazPtrRecord {
     pub(crate) ptr: AtomicPtr<u8>,
@@ -9,7 +8,7 @@ pub(crate) struct HazPtrRecord {
 
 impl HazPtrRecord {
     pub(crate) fn reset(&self) {
-        self.ptr.store(std::ptr::null_mut(), Ordering::Release);
+        self.ptr.store(crate::ptr::null_mut(), Ordering::Release);
     }
 
     pub(crate) fn protect(&self, ptr: *mut u8) {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,15 +1,81 @@
+#[cfg(all(not(feature = "std"), loom))]
+compile_error!("loom requires the standard library");
+
+//loom support
+
 #[cfg(loom)]
 pub(crate) mod atomic {
-    pub(crate) use loom::sync::atomic::{fence, AtomicIsize, AtomicPtr, AtomicU64, AtomicUsize};
+    pub(crate) use loom::sync::atomic::{
+        fence, AtomicIsize, AtomicPtr, AtomicU64, AtomicUsize, Ordering,
+    };
 }
-
 #[cfg(loom)]
 pub(crate) use loom::thread::yield_now;
 
-#[cfg(not(loom))]
+//std imports
+
+#[cfg(all(not(loom), feature = "std"))]
 pub(crate) mod atomic {
-    pub(crate) use std::sync::atomic::{fence, AtomicIsize, AtomicPtr, AtomicU64, AtomicUsize};
+    pub(crate) use std::sync::atomic::{
+        fence, AtomicIsize, AtomicPtr, AtomicU64, AtomicUsize, Ordering,
+    };
+}
+#[cfg(all(not(loom), feature = "std"))]
+pub(crate) use std::thread::yield_now;
+
+//both
+
+#[cfg(any(loom, feature = "std"))]
+pub(crate) mod marker {
+    pub(crate) use std::marker::PhantomData;
+}
+#[cfg(any(loom, feature = "std"))]
+pub(crate) mod ptr {
+    pub(crate) use std::ptr::{null, null_mut, NonNull, drop_in_place};
+}
+#[cfg(any(loom, feature = "std"))]
+pub(crate) mod mem {
+    pub(crate) use std::mem::transmute;
+}
+#[cfg(any(loom, feature = "std"))]
+pub(crate) mod boxed {
+    pub(crate) use std::boxed::Box;
+}
+#[cfg(any(loom, feature = "std"))]
+pub(crate) mod ops {
+    pub(crate) use std::ops::{Deref, DerefMut};
 }
 
-#[cfg(not(loom))]
-pub(crate) use std::thread::yield_now;
+//core imports
+
+#[cfg(all(not(loom), not(feature = "std")))]
+pub(crate) mod atomic {
+    pub(crate) use core::sync::atomic::{
+        fence, AtomicIsize, AtomicPtr, AtomicU64, AtomicUsize, Ordering,
+    };
+}
+
+#[cfg(all(not(loom), not(feature = "std")))]
+pub(crate) fn yield_now() {
+    //FIXME: What goes here?
+}
+#[cfg(all(not(loom), not(feature = "std")))]
+pub(crate) mod marker {
+    pub(crate) use core::marker::PhantomData;
+}
+#[cfg(all(not(loom), not(feature = "std")))]
+pub(crate) mod ptr {
+    pub(crate) use core::ptr::{null, null_mut, NonNull, drop_in_place};
+}
+#[cfg(all(not(loom), not(feature = "std")))]
+pub(crate) mod mem {
+    pub(crate) use core::mem::transmute;
+}
+#[cfg(all(not(loom), not(feature = "std")))]
+pub(crate) mod boxed {
+    pub(crate) use alloc::boxed::Box;
+}
+#[cfg(all(not(loom), not(feature = "std")))]
+pub(crate) mod ops {
+    pub(crate) use core::ops::{Deref, DerefMut};
+}


### PR DESCRIPTION
This is a new implementation of _calc_shard_ that uses a state word in Domain plus an xor and a multiply to compute shards with a better distribution. 

This prevents adding a dependency and produces quite good hashes compared to AHash and std's DefaultHasher:
I wrote a simulation program that calculates the quality of the spread for each algorithm based on real pointer values from the allocator. The full code is available here: https://github.com/TroyNeubauer/hash_test/blob/master/src/main.rs

<details>
<summary> Here is an example run of the simulation: </summary>


Shard distributions from the last run
Pointer Hash
  i=0:      129  XXXXXXXXXXXXXXXXXXXXXXXXX
  i=1:      137  XXXXXXXXXXXXXXXXXXXXXXXXXXX
  i=2:      186  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  i=3:      134  XXXXXXXXXXXXXXXXXXXXXXXXXX
  i=4:      117  XXXXXXXXXXXXXXXXXXXXXXX
  i=5:       80  XXXXXXXXXXXXXXXX
  i=6:      110  XXXXXXXXXXXXXXXXXXXXXX
  i=7:      107  XXXXXXXXXXXXXXXXXXXXX
Multiply Hash
  i=0:      119  XXXXXXXXXXXXXXXXXXXXXXX
  i=1:      145  XXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  i=2:      117  XXXXXXXXXXXXXXXXXXXXXXX
  i=3:      110  XXXXXXXXXXXXXXXXXXXXXX
  i=4:      122  XXXXXXXXXXXXXXXXXXXXXXXX
  i=5:      138  XXXXXXXXXXXXXXXXXXXXXXXXXXX
  i=6:      135  XXXXXXXXXXXXXXXXXXXXXXXXXXX
  i=7:      114  XXXXXXXXXXXXXXXXXXXXXX
Standard Hash
  i=0:      125  XXXXXXXXXXXXXXXXXXXXXXXXX
  i=1:      124  XXXXXXXXXXXXXXXXXXXXXXXX
  i=2:      115  XXXXXXXXXXXXXXXXXXXXXXX
  i=3:      135  XXXXXXXXXXXXXXXXXXXXXXXXXXX
  i=4:      111  XXXXXXXXXXXXXXXXXXXXXX
  i=5:      140  XXXXXXXXXXXXXXXXXXXXXXXXXXXX
  i=6:      121  XXXXXXXXXXXXXXXXXXXXXXXX
  i=7:      129  XXXXXXXXXXXXXXXXXXXXXXXXX
AHash
  i=0:      131  XXXXXXXXXXXXXXXXXXXXXXXXXX
  i=1:      109  XXXXXXXXXXXXXXXXXXXXX
  i=2:      145  XXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  i=3:      129  XXXXXXXXXXXXXXXXXXXXXXXXX
  i=4:      127  XXXXXXXXXXXXXXXXXXXXXXXXX
  i=5:      114  XXXXXXXXXXXXXXXXXXXXXX
  i=6:      132  XXXXXXXXXXXXXXXXXXXXXXXXXX
  i=7:      113  XXXXXXXXXXXXXXXXXXXXXX

Completed 10000 trials of 1000 inner runs
Average Standard Deviation by Algorithm:
Pointer Hash        : 2.4528438410815996
Multiply Hash       : 0.9047987100495352
Standard Hash       : 0.9037171038177603
AHash               : 0.904421036085782
</details>
This implementation is on par with hashing from the standard library and AHash for this use case. I couldn't find a _MOCK_SIZE_ or number of runs that lead to a > 10% standard deviation difference between Multiply Hash and the others. 
Interestingly, the pointer hash works decently well for being so simple lol.The simulation also allocates unrelated objects to simulate a user allocating objects other than hazard pointers.

These results look promising but should be taken with a grain of salt for using pointer values from my machine and for general weirdness for using pointer values as entropy.


Also the efficiency is quite good. On x86 LLVM produces a single mul instruction (64 bit inputs, 128 bit outputs) and is just 5 instructions total: https://godbolt.org/z/o1n15dncd

Linking the point in stream where you discuss this for reference: https://youtu.be/tGn0mQF0804?t=11883