### PR TITLE
acquire_many: 3 fixes, public API changes

### DIFF
--- a/src/holder.rs
+++ b/src/holder.rs
@@ -2,6 +2,52 @@ use crate::sync::atomic::AtomicPtr;
 use crate::{Domain, HazPtrObject, HazPtrRecord};
 use std::sync::atomic::Ordering;
 
+pub struct HazardPointerArray<'domain, F, const N: usize> {
+    domain: &'domain Domain<F>,
+    records: Option<[&'domain HazPtrRecord; N]>,
+}
+
+impl<'domain, F, const N: usize> HazardPointerArray<'domain, F, N> {
+    pub unsafe fn protect<'l, 'o, T>(
+        &'l mut self,
+        mut sources: [&'_ AtomicPtr<T>; N],
+    ) -> [Option<&'l T>; N]
+    where
+        T: HazPtrObject<'o, F>,
+        'o: 'l,
+        F: 'static,
+    {
+        let mut out = [None; N];
+
+        for (i, (hazptr, src)) in self
+            .records
+            .as_mut()
+            .expect("pointers exist")
+            .iter_mut()
+            .zip(&mut sources)
+            .enumerate()
+        {
+            out[i] = unsafe { protect(&self.domain, hazptr, src) };
+        }
+
+        out
+    }
+
+    pub fn reset_protection(&mut self) {
+        for hazptr in self.records.as_mut().expect("pointers exist") {
+            hazptr.reset();
+        }
+    }
+}
+
+impl<F, const N: usize> Drop for HazardPointerArray<'_, F, N> {
+    fn drop(&mut self) {
+        self.reset_protection();
+        let records = self.records.take().expect("pointers exist");
+        self.domain.release_many(records);
+    }
+}
+
 pub struct HazardPointer<'domain, F> {
     hazard: &'domain HazPtrRecord,
     domain: &'domain Domain<F>,
@@ -11,6 +57,10 @@ impl HazardPointer<'static, crate::Global> {
     pub fn make_global() -> Self {
         HazardPointer::make_in_domain(Domain::global())
     }
+
+    pub fn make_many_global<const N: usize>() -> HazardPointerArray<'static, crate::Global, N> {
+        HazardPointer::make_many_in_domain(Domain::global())
+    }
 }
 
 impl<'domain, F> HazardPointer<'domain, F> {
@@ -18,6 +68,17 @@ impl<'domain, F> HazardPointer<'domain, F> {
         Self {
             hazard: domain.acquire(),
             domain,
+        }
+    }
+
+    pub fn make_many_in_domain<const N: usize>(
+        domain: &'domain Domain<F>,
+    ) -> HazardPointerArray<'domain, F, N> {
+        let records = domain.acquire_many::<N>();
+
+        HazardPointerArray {
+            domain,
+            records: Some(records),
         }
     }
 
@@ -34,23 +95,7 @@ impl<'domain, F> HazardPointer<'domain, F> {
         'o: 'l,
         F: 'static,
     {
-        let mut ptr = src.load(Ordering::Relaxed);
-        loop {
-            // Safety: same safety requirements as try_protect.
-            match unsafe { self.try_protect(ptr, src) } {
-                Ok(None) => break None,
-                // Safety:
-                // This is needed to workaround a bug in the borrow checker. See:
-                // - https://github.com/rust-lang/rust/issues/51545
-                // - https://github.com/rust-lang/rust/issues/54663
-                // - https://github.com/rust-lang/rust/issues/58910
-                // - https://github.com/rust-lang/rust/issues/84361
-                Ok(Some(r)) => break Some(unsafe { &*(r as *const _) }),
-                Err(ptr2) => {
-                    ptr = ptr2;
-                }
-            }
-        }
+        unsafe { protect(&self.domain, &self.hazard, src) }
     }
 
     ///
@@ -60,7 +105,7 @@ impl<'domain, F> HazardPointer<'domain, F> {
     /// Caller must also guarantee that the value behind the `AtomicPtr` will only be deallocated
     /// through calls to [`HazPtrObject::retire`] on the same [`Domain`] as this holder is
     /// associated with.
-    pub unsafe fn try_protect<'l, 'o, T>(
+    unsafe fn try_protect<'l, 'o, T>(
         &'l mut self,
         ptr: *mut T,
         src: &'_ AtomicPtr<T>,
@@ -70,35 +115,92 @@ impl<'domain, F> HazardPointer<'domain, F> {
         'o: 'l,
         F: 'static,
     {
-        self.hazard.protect(ptr as *mut u8);
-
-        crate::asymmetric_light_barrier();
-
-        let ptr2 = src.load(Ordering::Acquire);
-        if ptr != ptr2 {
-            self.hazard.reset();
-            Err(ptr2)
-        } else {
-            // All good -- protected
-            Ok(std::ptr::NonNull::new(ptr).map(|nn| {
-                // Safety: this is safe because:
-                //
-                //  1. Target of ptr1 will not be deallocated for the returned lifetime since
-                //     our hazard pointer is active and pointing at ptr1.
-                //  2. Pointer address is valid by the safety contract of load.
-                let r = unsafe { nn.as_ref() };
-                debug_assert_eq!(
-                    self.domain as *const Domain<F>,
-                    r.domain() as *const Domain<F>,
-                    "object guarded by different domain than holder used to access it"
-                );
-                r
-            }))
-        }
+        unsafe { try_protect(&self.domain, &self.hazard, ptr, src) }
     }
 
     pub fn reset_protection(&mut self) {
         self.hazard.reset();
+    }
+}
+
+///
+/// # Safety
+///
+/// Caller must guarantee that the address in `AtomicPtr` is valid as a reference, or null.
+/// Caller must also guarantee that the value behind the `AtomicPtr` will only be deallocated
+/// through calls to [`HazPtrObject::retire`] on the same [`Domain`] as this holder is
+/// associated with.
+unsafe fn protect<'domain, 'l, 'o, F, T>(
+    domain: &'l &'domain Domain<F>,
+    hazard: &'l &'domain HazPtrRecord,
+    src: &'_ AtomicPtr<T>,
+) -> Option<&'l T>
+where
+    T: HazPtrObject<'o, F>,
+    'o: 'l,
+    F: 'static,
+{
+    let mut ptr = src.load(Ordering::Relaxed);
+    loop {
+        // Safety: same safety requirements as try_protect.
+        match unsafe { try_protect(domain, hazard, ptr, src) } {
+            Ok(None) => break None,
+            // Safety:
+            // This is needed to workaround a bug in the borrow checker. See:
+            // - https://github.com/rust-lang/rust/issues/51545
+            // - https://github.com/rust-lang/rust/issues/54663
+            // - https://github.com/rust-lang/rust/issues/58910
+            // - https://github.com/rust-lang/rust/issues/84361
+            Ok(Some(r)) => break Some(unsafe { &*(r as *const _) }),
+            Err(ptr2) => {
+                ptr = ptr2;
+            }
+        }
+    }
+}
+
+///
+/// # Safety
+///
+/// Caller must guarantee that the address in `AtomicPtr` is valid as a reference, or null.
+/// Caller must also guarantee that the value behind the `AtomicPtr` will only be deallocated
+/// through calls to [`HazPtrObject::retire`] on the same [`Domain`] as this holder is
+/// associated with.
+unsafe fn try_protect<'domain, 'l, 'o, F, T>(
+    domain: &'l &'domain Domain<F>,
+    hazard: &'l &'domain HazPtrRecord,
+    ptr: *mut T,
+    src: &'_ AtomicPtr<T>,
+) -> Result<Option<&'l T>, *mut T>
+where
+    T: HazPtrObject<'o, F>,
+    'o: 'l,
+    F: 'static,
+{
+    hazard.protect(ptr as *mut u8);
+
+    crate::asymmetric_light_barrier();
+
+    let ptr2 = src.load(Ordering::Acquire);
+    if ptr != ptr2 {
+        hazard.reset();
+        Err(ptr2)
+    } else {
+        // All good -- protected
+        Ok(std::ptr::NonNull::new(ptr).map(|nn| {
+            // Safety: this is safe because:
+            //
+            //  1. Target of ptr1 will not be deallocated for the returned lifetime since
+            //     our hazard pointer is active and pointing at ptr1.
+            //  2. Pointer address is valid by the safety contract of load.
+            let r = unsafe { nn.as_ref() };
+            debug_assert_eq!(
+                *domain as *const Domain<F>,
+                r.domain() as *const Domain<F>,
+                "object guarded by different domain than holder used to access it"
+            );
+            r
+        }))
     }
 }
 

--- a/src/holder.rs
+++ b/src/holder.rs
@@ -64,6 +64,7 @@ impl<'domain, F, const N: usize> Drop for HazardPointerArray<'domain, F, N> {
     fn drop(&mut self) {
         self.reset_protection();
         let domain = self.haz_ptrs[0].domain;
+        // replace with `self.haz_ptrs.each_ref().map(|v| v.hazard)` when each_ref stabilizes
         let records = self.hazard_pointers().map(|hazptr| hazptr.hazard);
         domain.release_many(records);
     }

--- a/src/holder.rs
+++ b/src/holder.rs
@@ -146,7 +146,7 @@ impl<'domain, F> HazardPointer<'domain, F> {
     /// Caller must also guarantee that the value behind the `AtomicPtr` will only be deallocated
     /// through calls to [`HazPtrObject::retire`] on the same [`Domain`] as this holder is
     /// associated with.
-    unsafe fn try_protect<'l, 'o, T>(
+    pub unsafe fn try_protect<'l, 'o, T>(
         &'l mut self,
         ptr: *mut T,
         src: &'_ AtomicPtr<T>,

--- a/src/holder.rs
+++ b/src/holder.rs
@@ -4,8 +4,8 @@ use std::mem::{ManuallyDrop, MaybeUninit};
 use std::sync::atomic::Ordering;
 
 pub struct HazardPointerArray<'domain, F, const N: usize> {
-    // ManuallyDrop is required to prevent the HazardPointer from returning itself, since
-    // HazardPointerArray has it's own drop implementation with an optimized return for allow hazard
+    // ManuallyDrop is required to prevent the HazardPointer from reclaiming itself, since
+    // HazardPointerArray has it's own drop implementation with an optimized reclaim for all hazard
     // pointers
     haz_ptrs: [ManuallyDrop<HazardPointer<'domain, F>>; N],
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -27,8 +27,7 @@ fn acquires_multiple() {
     ))));
 
     // As a reader:
-    // let hazptrs = HazardPointer::make_many_global::<2>();
-    let mut hazptr_array = HazardPointer::make_many_in_domain::<2>(&domain);
+    let mut hazptr_array = HazardPointer::make_many_in_domain(&domain);
 
     // Safety:
     //
@@ -56,8 +55,6 @@ fn acquires_multiple() {
     assert_eq!(my_x.0, 42);
     assert_eq!(my_y.0, 42);
 
-    // valid:
-    assert_eq!(my_y.0, 42);
     drop(hazptr_array);
     // invalid:
     // let _: i32 = my_y.0;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -33,14 +33,14 @@ fn acquires_multiple() {
     //
     //  1. AtomicPtr points to a Box, so is always valid.
     //  2. Writers to AtomicPtr use HazPtrObject::retire.
-    let [my_x, my_y] = unsafe { hazptr_array.protect([&x, &y]) };
-
-    let my_x = my_x.expect("not null");
-    let my_y = my_y.expect("not null");
+    let [mut one, mut two] = hazptr_array.protectors();
+    let my_x = unsafe { one.protect(&x) }.expect("not null");
+    let my_y = unsafe { two.protect(&y) }.expect("not null");
 
     // valid:
     assert_eq!(my_x.0, 42);
     assert_eq!(my_y.0, 42);
+
     hazptr_array.reset_protection();
     // invalid:
     // let _: i32 = my_x.0;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -33,7 +33,7 @@ fn acquires_multiple() {
     //
     //  1. AtomicPtr points to a Box, so is always valid.
     //  2. Writers to AtomicPtr use HazPtrObject::retire.
-    let [mut one, mut two] = hazptr_array.protectors();
+    let [one, two] = hazptr_array.hazard_pointers();
     let my_x = unsafe { one.protect(&x) }.expect("not null");
     let my_y = unsafe { two.protect(&y) }.expect("not null");
 
@@ -46,7 +46,7 @@ fn acquires_multiple() {
     // let _: i32 = my_x.0;
     // let _: i32 = my_y.0;
 
-    let [my_x, my_y] = unsafe { hazptr_array.protect([&x, &y]) };
+    let [my_x, my_y] = unsafe { hazptr_array.protect_all([&x, &y]) };
 
     let my_x = my_x.expect("not null");
     let my_y = my_y.expect("not null");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,6 +12,71 @@ impl Drop for CountDrops {
 }
 
 #[test]
+fn acquires_multiple() {
+    let drops_42 = Arc::new(AtomicUsize::new(0));
+
+    let domain = Domain::new(&());
+
+    let x = AtomicPtr::new(Box::into_raw(Box::new(HazPtrObjectWrapper::with_domain(
+        &domain,
+        (42, CountDrops(Arc::clone(&drops_42))),
+    ))));
+    let y = AtomicPtr::new(Box::into_raw(Box::new(HazPtrObjectWrapper::with_domain(
+        &domain,
+        (42, CountDrops(Arc::clone(&drops_42))),
+    ))));
+
+    // As a reader:
+    // let hazptrs = HazardPointer::make_many_global::<2>();
+    let mut hazptr_array = HazardPointer::make_many_in_domain::<2>(&domain);
+
+    // Safety:
+    //
+    //  1. AtomicPtr points to a Box, so is always valid.
+    //  2. Writers to AtomicPtr use HazPtrObject::retire.
+    let [my_x, my_y] = unsafe { hazptr_array.protect([&x, &y]) };
+
+    let my_x = my_x.expect("not null");
+    let my_y = my_y.expect("not null");
+
+    // valid:
+    assert_eq!(my_x.0, 42);
+    assert_eq!(my_y.0, 42);
+    hazptr_array.reset_protection();
+    // invalid:
+    // let _: i32 = my_x.0;
+    // let _: i32 = my_y.0;
+
+    let [my_x, my_y] = unsafe { hazptr_array.protect([&x, &y]) };
+
+    let my_x = my_x.expect("not null");
+    let my_y = my_y.expect("not null");
+
+    // valid:
+    assert_eq!(my_x.0, 42);
+    assert_eq!(my_y.0, 42);
+
+    // valid:
+    assert_eq!(my_y.0, 42);
+    drop(hazptr_array);
+    // invalid:
+    // let _: i32 = my_y.0;
+    // invalid:
+    // let _: i32 = my_y.0;
+
+    domain.eager_reclaim();
+    assert_eq!(drops_42.load(Ordering::SeqCst), 0);
+
+    unsafe { x.into_inner().retire(&deleters::drop_box) };
+    domain.eager_reclaim();
+    assert_eq!(drops_42.load(Ordering::SeqCst), 1);
+
+    unsafe { y.into_inner().retire(&deleters::drop_box) };
+    domain.eager_reclaim();
+    assert_eq!(drops_42.load(Ordering::SeqCst), 2);
+}
+
+#[test]
 fn feels_good() {
     let drops_42 = Arc::new(AtomicUsize::new(0));
 

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -46,7 +46,7 @@ fn acquires_multiple() {
         let t1 = thread::spawn(move || {
             let mut hazptr_array = HazardPointer::make_many_in_domain(&domain);
 
-            let [my_x, my_y] = unsafe { hazptr_array.protect([&x1, &y1]) };
+            let [my_x, my_y] = unsafe { hazptr_array.protect_all([&x1, &y1]) };
 
             let my_x = my_x.expect("not null");
             let my_y = my_y.expect("not null");


### PR DESCRIPTION
# Public API change
Add `make_many_in_domain` for creating many hazard pointers in an array, but not exposing that array directly to consumers of the library. There is a `protect` method on the new struct, which accepts an array of pointers and returns an array of references. This is useful both for consumers of the library but also for writing tests in the `tests` folder. Additional tests have been written in a tests module in domain.


# Fix 1
Update head to the next available Hazard Pointer Record rather than the next hazard pointer record, as we should only be returning available records.

## Previous behavior demonstrated
suppose we have a list of the following records
```
0: Rec {
  next: 1,
  next_available: 2,
}
1: Rec {
  next: 2,
  next_available: null,
}
2: Rec {
  next: null,
  next_available: null
}
```
A call to `try_acquire_many` would count the available nodes and return `n = 2`, but when we build our array of nodes, we'd put in nodes `0` and `1`, rather than nodes `0` and `2`, since we'd take `next` on each record rather than `next_available`

If we had called `acquire_many` with `N = 3`, we'd end up with an array of `[0, 1, 2]` rather than an array of `[0, 2, New]`

# Fix 2
Properly order the newly created Hazard Pointer Records in relation to the existing records that were acquired. This reverse the direction of the links from pointing from record `i` to `i-1` to instead point from record `i` to `i+1`.

## Previous behavior demonstrated:
suppose `try_acquire_many` returned n = 3 and N is 5, we'd have an array of the following:
```
each step:
# 1
head = Rec { next_available: 1 }
tail = null
built_array = [
  0: Rec { next_available: 1 },
  ...
]

# 2
head = Rec { next_available: 2 }
tail = Rec { next_available: 1 }
build_array =  [
  0: Rec { next_available: 1 },
  1: Rec { next_available: 2 },
  ...
]

# 3
head = Rec { next_available: null }
tail = Rec { next_available: 2 }
built_array = [
  0: Rec { next_available: 1 },
  1: Rec { next_available: 2 },
  2: Rec { next_available: null },
  ...
]

# Then we'd get to our newly created records
# 4 
head = null
tail = Rec { next_available: null }
rec = Rec { next_available: null }
rec.next_available = tail
built_array = [
  0: Rec { next_available: 1 },
  1: Rec { next_available: 2 },
  2: Rec { next_available: null },
  3: Rec { next_available: 2 },
  ...
]

# 5
head = null
tail = Rec { next_available: 2 }
rec = Rec { next_available: null }
rec.next_available = tail
built_array = [
  0: Rec { next_available: 1 },
  1: Rec { next_available: 2 },
  2: Rec { next_available: null },
  3: Rec { next_available: 2 }, // points backwards
  4: Rec { next_available: 3 }, // points backwards
]
```
With the previous behavior, we construct a list with two heads, each pointing inwards to share a tail

By changing `rec.next_available = tail` to `tail.next_available = rec` we can maintain proper ordering of our list

# Fix 3
Move `head` assignment to before it gets overridden with `head->available_next`. This ensures that `head` will always be the "previous node" in the list.