### PR TITLE
Improve shard hash function to use 128 bit mutiply with xor #2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "haphazard"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+multiply_hash= []
 
 [dependencies]
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -48,6 +48,7 @@ pub struct Domain<F> {
     nbulk_reclaims: AtomicUsize,
     count: AtomicIsize,
     shutdown: bool,
+    shard_hash_state: AtomicUsize,
 }
 
 impl Domain<Global> {
@@ -89,6 +90,7 @@ macro_rules! new {
                 nbulk_reclaims: AtomicUsize::new(0),
                 family: PhantomData,
                 shutdown: false,
+                shard_hash_state: AtomicUsize::new(0),
             }
         }
     };
@@ -301,7 +303,7 @@ impl<F> Domain<F> {
         crate::asymmetric_light_barrier();
 
         let retired = Box::into_raw(retired);
-        unsafe { self.untagged[Self::calc_shard(retired)].push(retired, retired) };
+        unsafe { self.untagged[self.calc_shard(retired)].push(retired, retired) };
         self.count.fetch_add(1, Ordering::Release);
 
         self.check_threshold_and_reclaim()
@@ -549,12 +551,25 @@ impl<F> Domain<F> {
     }
 
     #[cfg(not(loom))]
-    fn calc_shard(input: *mut Retired) -> usize {
-        (input as usize >> IGNORED_LOW_BITS) & SHARD_MASK
+    fn calc_shard(&self, input: *mut Retired) -> usize {
+        //XXX: This is not prime when truncated to 32 bits
+        const LARGE_PRIME: usize = 4445950232728569541;
+        let input = input as usize ^ self.shard_hash_state.load(Ordering::Relaxed);
+
+        //XXX: Could be made simpler without the slice stuff using mem::transmute
+        let mul_result = (input as u128 * LARGE_PRIME as u128).to_ne_bytes();
+        let mut hash = [0u8; 8];
+        hash.copy_from_slice(&mul_result[0..8]);
+
+        let mut new_state = [0u8; 8];
+        new_state.copy_from_slice(&mul_result[8..16]);
+
+        self.shard_hash_state.store(u64::from_ne_bytes(new_state) as usize, Ordering::Relaxed);
+        u64::from_ne_bytes(hash) as usize & SHARD_MASK
     }
 
     #[cfg(loom)]
-    fn calc_shard(_input: *mut Retired) -> usize {
+    fn calc_shard(&self, _input: *mut Retired) -> usize {
         SHARD.fetch_add(1, Ordering::Relaxed) & SHARD_MASK
     }
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -550,9 +550,9 @@ impl<F> Domain<F> {
         }
     }
 
-    #[cfg(not(loom))]
+    #[cfg(all(not(loom), feature = "multiply_hash"))]
     fn calc_shard(&self, input: *mut Retired) -> usize {
-        //XXX: This is not prime when truncated to 32 bits
+        //XXX: This is not prime if a usize 32 bits
         const LARGE_PRIME: usize = 4445950232728569541;
         let input = input as usize ^ self.shard_hash_state.load(Ordering::Relaxed);
 
@@ -566,6 +566,11 @@ impl<F> Domain<F> {
 
         self.shard_hash_state.store(u64::from_ne_bytes(new_state) as usize, Ordering::Relaxed);
         u64::from_ne_bytes(hash) as usize & SHARD_MASK
+    }
+
+    #[cfg(all(not(loom), not(feature = "multiply_hash")))]
+    fn calc_shard(&self, input: *mut Retired) -> usize {
+        (input as usize >> IGNORED_LOW_BITS) & SHARD_MASK
     }
 
     #[cfg(loom)]


### PR DESCRIPTION
New PR for #8, with `no_std` support split up into #11.