### PR TITLE
Fix ci

### DIFF
--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -1,5 +1,5 @@
 jobs:
- - template: default.yml@templates
+ - template: nightly-only.yml@templates
    parameters:
      minrust: 1.56.0
      nightly: true
@@ -24,4 +24,4 @@ resources:
       type: github
       name: crate-ci/azure-pipelines
       ref: refs/heads/v0.4
-      endpoint: jonhoo
+      endpoint: TroyNeubauer

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -18,6 +18,8 @@ jobs:
           - aarch64-unknown-none
      - bash: cargo check --target aarch64-unknown-none --no-default-features
        displayName: cargo check
+     - bash: ! cargo check --target aarch64-unknown-none
+       displayName: Compilation fails with (default feature) std enabled
  - job: clippy 
    displayName: "Clippy warnings"
    pool:

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -18,7 +18,8 @@ jobs:
           - aarch64-unknown-none
      - bash: cargo check --target aarch64-unknown-none --no-default-features
        displayName: cargo check
-     - bash: "! cargo check --target aarch64-unknown-none"
+     - script: |
+        ! cargo check --target aarch64-unknown-none
        displayName: Compilation fails with (default feature) std enabled
  - job: clippy 
    displayName: "Clippy warnings"

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -47,6 +47,15 @@ jobs:
        displayName: cargo miri test
        env:
          MIRIFLAGS: -Zmiri-ignore-leaks
+ - job: loom
+   displayName: "Run loom on test suite"
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+     - script: RUSTFLAGS="--cfg loom" cargo test --release --test loom
+       displayName: cargo test --test loom
  - job: asan
    displayName: "Run address sanitizer on test suite"
    pool:

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -18,7 +18,7 @@ jobs:
           - aarch64-unknown-none
      - bash: cargo check --target aarch64-unknown-none --no-default-features
        displayName: cargo check
-     - bash: ! cargo check --target aarch64-unknown-none
+     - bash: "! cargo check --target aarch64-unknown-none"
        displayName: Compilation fails with (default feature) std enabled
  - job: clippy 
    displayName: "Clippy warnings"

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -53,7 +53,6 @@ jobs:
      vmImage: ubuntu-latest
    steps:
      - template: install-rust.yml@templates
-       parameters:
      - script: RUSTFLAGS="--cfg loom" cargo test --release --test loom
        displayName: cargo test --test loom
  - job: asan

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -10,7 +10,7 @@ jobs:
  - job: no_std
    displayName: "Compile-check on no_std target"
    pool:
-     vmImage: ubuntu-16.04
+     vmImage: ubuntu-20.04
    steps:
      - template: install-rust.yml@templates
        parameters:

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -18,6 +18,68 @@ jobs:
           - aarch64-unknown-none
      - bash: cargo check --target aarch64-unknown-none --no-default-features
        displayName: cargo check
+ - job: clippy 
+   displayName: "Clippy warnings"
+   dependsOn: deny
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+         rust: beta
+         components:
+           - clippy
+     - bash: cargo clippy --all-features -- -D warnings
+       displayName: cargo clippy -- -D warnings
+ - job: miri
+   displayName: "Run miri on test suite"
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - bash: |
+         echo '##vso[task.setvariable variable=nightly]nightly-'$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+       displayName: "Determine latest miri nightly"
+     - template: install-rust.yml@templates
+       parameters:
+         rust: $(nightly)
+         components:
+           - miri
+     - script: cargo miri test
+       displayName: cargo miri test
+       env:
+         MIRIFLAGS: -Zmiri-ignore-leaks
+ - job: asan
+   displayName: "Run address sanitizer on test suite"
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+         rust: nightly
+     - bash: |
+           sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer
+       displayName: Enable debug symbols
+     # only --lib --tests b/c of https://github.com/rust-lang/rust/issues/53945
+     - script: |
+           env ASAN_OPTIONS="detect_odr_violation=0" RUSTFLAGS="-Z sanitizer=address" cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu
+       displayName: cargo -Z sanitizer=address test
+ - job: lsan
+   displayName: "Run leak sanitizer on test suite"
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+         rust: nightly
+     - bash: |
+           sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer
+           sed -i '/\[features\]/i [profile.dev]' Cargo.toml
+           sed -i '/profile.dev/a opt-level = 1' Cargo.toml
+           cat Cargo.toml
+       displayName: Enable debug symbols
+     - script: |
+           env RUSTFLAGS="-Z sanitizer=leak" cargo test --all-features --target x86_64-unknown-linux-gnu
+       displayName: cargo -Z sanitizer=leak test
 resources:
   repositories:
     - repository: templates

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -15,8 +15,8 @@ jobs:
      - template: install-rust.yml@templates
        parameters:
          targets:
-          - thumbv7m-none-eabi
-     - bash: cargo check --target thumbv7m-none-eabi --no-default-features
+          - aarch64-unknown-none
+     - bash: cargo check --target aarch64-unknown-none --no-default-features
        displayName: cargo check
 resources:
   repositories:

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -60,25 +60,8 @@ jobs:
        displayName: Enable debug symbols
      # only --lib --tests b/c of https://github.com/rust-lang/rust/issues/53945
      - script: |
-           env ASAN_OPTIONS="detect_odr_violation=0" RUSTFLAGS="-Z sanitizer=address" cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu
-       displayName: cargo -Z sanitizer=address test
- - job: lsan
-   displayName: "Run leak sanitizer on test suite"
-   pool:
-     vmImage: ubuntu-latest
-   steps:
-     - template: install-rust.yml@templates
-       parameters:
-         rust: nightly
-     - bash: |
-           sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer
-           sed -i '/\[features\]/i [profile.dev]' Cargo.toml
-           sed -i '/profile.dev/a opt-level = 1' Cargo.toml
-           cat Cargo.toml
-       displayName: Enable debug symbols
-     - script: |
-           env RUSTFLAGS="-Z sanitizer=leak" cargo test --all-features --target x86_64-unknown-linux-gnu
-       displayName: cargo -Z sanitizer=leak test
+           env ASAN_OPTIONS="detect_odr_violation=0:detect_leaks=0" RUSTFLAGS="-Z sanitizer=address" cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu
+       displayName: cargo -Z sanitizer=address test 
 resources:
   repositories:
     - repository: templates

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -1,12 +1,10 @@
 jobs:
- - template: nightly-only.yml@templates
+ - template: default.yml@templates
    parameters:
      minrust: 1.56.0
-     nightly: true
  - template: coverage.yml@templates
    parameters:
      token: $(CODECOV_TOKEN_SECRET)
-     nightly: true
  - job: no_std
    displayName: "Compile-check on no_std target"
    pool:

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -20,7 +20,6 @@ jobs:
        displayName: cargo check
  - job: clippy 
    displayName: "Clippy warnings"
-   dependsOn: deny
    pool:
      vmImage: ubuntu-latest
    steps:

--- a/azure-pipeliens.yml
+++ b/azure-pipeliens.yml
@@ -18,19 +18,7 @@ jobs:
        displayName: cargo check
      - script: |
         ! cargo check --target aarch64-unknown-none
-       displayName: Compilation fails with (default feature) std enabled
- - job: clippy 
-   displayName: "Clippy warnings"
-   pool:
-     vmImage: ubuntu-latest
-   steps:
-     - template: install-rust.yml@templates
-       parameters:
-         rust: beta
-         components:
-           - clippy
-     - bash: cargo clippy --all-features -- -D warnings
-       displayName: cargo clippy -- -D warnings
+       displayName: Compilation fails with (default feature) std enabled 
  - job: miri
    displayName: "Run miri on test suite"
    pool:
@@ -70,11 +58,11 @@ jobs:
      # only --lib --tests b/c of https://github.com/rust-lang/rust/issues/53945
      - script: |
            env ASAN_OPTIONS="detect_odr_violation=0:detect_leaks=0" RUSTFLAGS="-Z sanitizer=address" cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu
-       displayName: cargo -Z sanitizer=address test 
+       displayName: cargo -Z sanitizer=address test
 resources:
   repositories:
     - repository: templates
       type: github
       name: crate-ci/azure-pipelines
       ref: refs/heads/v0.4
-      endpoint: TroyNeubauer
+      endpoint: jonhoo 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,10 +5,24 @@ jobs:
  - template: coverage.yml@templates
    parameters:
      token: $(CODECOV_TOKEN_SECRET)
- - job: no_std
-   displayName: "Compile-check on no_std target"
+ - job: no_std_32bit
+   displayName: "Compile-check on 32 bit no_std target"
    pool:
-     vmImage: ubuntu-20.04
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+         targets:
+          - thumbv7m-none-eabi
+     - bash: cargo check --target thumbv7m-none-eabi --no-default-features
+       displayName: cargo check
+     - script: |
+        ! cargo check --target thumbv7m-none-eabi
+       displayName: Compilation fails with std enabled 
+ - job: no_std_64bit
+   displayName: "Compile-check on 64 bit no_std target"
+   pool:
+     vmImage: ubuntu-latest
    steps:
      - template: install-rust.yml@templates
        parameters:
@@ -18,7 +32,7 @@ jobs:
        displayName: cargo check
      - script: |
         ! cargo check --target aarch64-unknown-none
-       displayName: Compilation fails with (default feature) std enabled 
+       displayName: Compilation fails with std enabled 
  - job: miri
    displayName: "Run miri on test suite"
    pool:
@@ -65,4 +79,4 @@ resources:
       type: github
       name: crate-ci/azure-pipelines
       ref: refs/heads/v0.4
-      endpoint: jonhoo 
+      endpoint: jonhoo

--- a/benches/folly.rs
+++ b/benches/folly.rs
@@ -48,7 +48,7 @@ folly_bench!(concurrent_new_holder, {
 });
 folly_bench!(concurrent_retire, {
     let foo = Box::into_raw(Box::new(HazPtrObjectWrapper::with_global_domain(0)));
-    black_box(unsafe { foo.retire(&deleters::drop_box) });
+    black_box(unsafe { HazPtrObjectWrapper::retire(foo, &deleters::drop_box) });
 });
 
 criterion_group!(benches, concurrent_new_holder, concurrent_retire);

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,4 +1,4 @@
-use crate::sync::atomic::{AtomicIsize, AtomicPtr, AtomicU64, AtomicUsize};
+use crate::sync::atomic::{AtomicIsize, AtomicPtr, AtomicUsize};
 use crate::{Deleter, HazPtrRecord, Reclaim};
 use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
@@ -7,6 +7,8 @@ use core::sync::atomic::Ordering;
 
 #[cfg(all(feature = "std", not(miri)))]
 const SYNC_TIME_PERIOD: u64 = std::time::Duration::from_nanos(2000000000).as_nanos() as u64;
+#[cfg(all(feature = "std", not(miri)))]
+use crate::sync::atomic::AtomicU64;
 
 const RCOUNT_THRESHOLD: isize = 1000;
 const HCOUNT_MULTIPLIER: isize = 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(arbitrary_self_types)]
+//#![feature(arbitrary_self_types)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(dead_code)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-//#![feature(arbitrary_self_types)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(dead_code)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/object.rs
+++ b/src/object.rs
@@ -20,6 +20,8 @@ where
     ///
     /// It is okay for existing readers to still refer to Self.
     ///   
+    //TODO: Once arbitrary_self_types is stabilized change `this` back to `self`.
+    //See: https://github.com/rust-lang/rust/issues/44874
     unsafe fn retire(this: *mut Self, deleter: &'static dyn Deleter) -> usize {
         let ptr = this as *mut (dyn Reclaim + 'domain);
         unsafe { (&*this).domain().retire(ptr, deleter) }

--- a/src/object.rs
+++ b/src/object.rs
@@ -16,9 +16,9 @@ where
     ///
     /// It is okay for existing readers to still refer to Self.
     ///   
-    unsafe fn retire(self: *mut Self, deleter: &'static dyn Deleter) -> usize {
-        let ptr = self as *mut (dyn Reclaim + 'domain);
-        unsafe { (&*self).domain().retire(ptr, deleter) }
+    unsafe fn retire(this: *mut Self, deleter: &'static dyn Deleter) -> usize {
+        let ptr = this as *mut (dyn Reclaim + 'domain);
+        unsafe { (&*this).domain().retire(ptr, deleter) }
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -10,7 +10,9 @@ pub(crate) use loom::thread::yield_now;
 
 #[cfg(not(loom))]
 pub(crate) mod atomic {
-    pub(crate) use core::sync::atomic::{fence, AtomicIsize, AtomicPtr, AtomicU64, AtomicUsize};
+    pub(crate) use core::sync::atomic::{fence, AtomicIsize, AtomicPtr, AtomicUsize};
+    #[cfg(target_pointer_width = "64")]
+    pub use core::sync::atomic::AtomicU64;
 }
 #[cfg(all(not(loom), feature = "std"))]
 pub(crate) use std::thread::yield_now;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -64,11 +64,11 @@ fn acquires_multiple() {
     domain.eager_reclaim();
     assert_eq!(drops_42.load(Ordering::SeqCst), 0);
 
-    unsafe { x.into_inner().retire(&deleters::drop_box) };
+    unsafe { HazPtrObjectWrapper::retire(x.into_inner(), &deleters::drop_box) };
     domain.eager_reclaim();
     assert_eq!(drops_42.load(Ordering::SeqCst), 1);
 
-    unsafe { y.into_inner().retire(&deleters::drop_box) };
+    unsafe { HazPtrObjectWrapper::retire(y.into_inner(), &deleters::drop_box) };
     domain.eager_reclaim();
     assert_eq!(drops_42.load(Ordering::SeqCst), 2);
 }
@@ -130,7 +130,7 @@ fn feels_good() {
     //  1. The pointer came from Box, so is valid.
     //  2. The old value is no longer accessible.
     //  3. The deleter is valid for Box types.
-    unsafe { old.retire(&deleters::drop_box) };
+    unsafe { HazPtrObjectWrapper::retire(old, &deleters::drop_box) };
 
     assert_eq!(drops_42.load(Ordering::SeqCst), 0);
     assert_eq!(my_x.0, 42);
@@ -207,7 +207,7 @@ fn drop_domain() {
     assert_eq!(drops_42.load(Ordering::SeqCst), 0);
     assert_eq!(my_x.0, 42);
 
-    unsafe { old.retire(&deleters::drop_box) };
+    unsafe { HazPtrObjectWrapper::retire(old, &deleters::drop_box) };
 
     assert_eq!(drops_42.load(Ordering::SeqCst), 0);
     assert_eq!(my_x.0, 42);

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -288,7 +288,7 @@ fn folly_cleanup() {
                     for j in (tid..THREAD_OPS).step_by(NUM_THREADS) {
                         let obj = Node::new(count, j, std::ptr::null_mut());
                         let p = Box::into_raw(Box::new(HazPtrObjectWrapper::with_domain(&D, obj)));
-                        unsafe { p.retire(&deleters::drop_box) };
+                        unsafe { HazPtrObjectWrapper::retire(p, &deleters::drop_box) };
                     }
                     threads_done.fetch_add(1, Ordering::AcqRel);
                     let _ = main_done.lock();
@@ -299,7 +299,7 @@ fn folly_cleanup() {
             for i in 0..MAIN_OPS {
                 let obj = Node::new(count, i, std::ptr::null_mut());
                 let p = Box::into_raw(Box::new(HazPtrObjectWrapper::with_domain(&D, obj)));
-                unsafe { p.retire(&deleters::drop_box) };
+                unsafe { HazPtrObjectWrapper::retire(p, &deleters::drop_box) };
             }
         }
         while threads_done.load(Ordering::Acquire) < NUM_THREADS {

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -69,12 +69,12 @@ fn acquires_multiple() {
         assert_eq!(ndrops_1.load(Ordering::SeqCst), 0);
         assert_eq!(ndrops_2.load(Ordering::SeqCst), 0);
 
-        unsafe { x.load(Ordering::SeqCst).retire(&deleters::drop_box) };
+        unsafe { HazPtrObjectWrapper::retire(x.load(Ordering::SeqCst), &deleters::drop_box) };
         domain.eager_reclaim();
         assert_eq!(ndrops_1.load(Ordering::SeqCst), 1);
         assert_eq!(ndrops_2.load(Ordering::SeqCst), 0);
 
-        unsafe { y.load(Ordering::SeqCst).retire(&deleters::drop_box) };
+        unsafe { HazPtrObjectWrapper::retire(y.load(Ordering::SeqCst), &deleters::drop_box) };
         domain.eager_reclaim();
         assert_eq!(ndrops_1.load(Ordering::SeqCst), 1);
         assert_eq!(ndrops_2.load(Ordering::SeqCst), 1);
@@ -118,7 +118,7 @@ fn single_reader_protection() {
             )))),
             std::sync::atomic::Ordering::SeqCst,
         );
-        let n0 = unsafe { old.retire(&deleters::drop_box) };
+        let n0 = unsafe { HazPtrObjectWrapper::retire(old, &deleters::drop_box) };
 
         let n1 = Domain::global().eager_reclaim();
 
@@ -183,7 +183,7 @@ fn multi_reader_protection() {
             )))),
             std::sync::atomic::Ordering::SeqCst,
         );
-        let n0 = unsafe { old.retire(&deleters::drop_box) };
+        let n0 = unsafe { HazPtrObjectWrapper::retire(old, &deleters::drop_box) };
 
         let n1 = Domain::global().eager_reclaim();
 


### PR DESCRIPTION
This PR ports over most of Flutty's CI config, including:
* Miri
* Loom
* Address Sanitizer
* Checking to see if a no_std target compiles without default features
* Checking to see if a no_std target doesn't compile with std enabled!
* Clippy, clippy with all features, clippy with no features

This disables due_time checking when on miri, and places the `due_time` variable behind a #[cfg] guard. 
Also this adds support for the stable channel by getting rid of the `arbitrary_self_types` feature. This means all instances where `.retire` could be called on a `*mut HazPtrObjectWrapper` must be replaced with `HazPtrObjectWrapper::retire`. 
This is a little sad. Possibly we could add a `retire` function in the crate's root that calls `HazPtrObjectWrapper::retire` to make user code a little cleaner, but `haphazard::retire(..., deleter)` is still much more cumbersome than `(...).retire(deleter)`.

Clippy isn't happy at the moment, but all other tasks pass. 