### PR TITLE
allow call AtomicPtr::safe_load to domais generated by unique_domain!

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -47,11 +47,10 @@ impl Global {
     }
 }
 
-
 /// Mark a [domain family](Domain) that unique caracterize a [domain instance](Domain)
-/// 
+///
 /// See [`Global`] and [`unique_domain`]
-/// 
+///
 /// # Safety
 ///
 /// Implementors of this trait must guarantee only one Domain of that family can be contructed.
@@ -164,18 +163,16 @@ impl Domain<Global> {
 }
 
 /// Generate a [`Domain`] with an entirely unique domain family.
-/// The generated family implements [`Singleton`], 
+/// The generated family implements [`Singleton`],
 #[macro_export]
 macro_rules! unique_domain {
-    () => {
-        {
-            struct UniqueFamily;
-            // Safety: UniqueFamily is only visible inside this scope, 
-            // therefore no other Domain of that family can be constructed.
-            unsafe impl Singleton for UniqueFamily {}
-            Domain::new(&UniqueFamily)
-        }
-    };
+    () => {{
+        struct UniqueFamily;
+        // Safety: UniqueFamily is only visible inside this scope,
+        // therefore no other Domain of that family can be constructed.
+        unsafe impl Singleton for UniqueFamily {}
+        Domain::new(&UniqueFamily)
+    }};
 }
 
 // Macro to make new const only when not in loom.

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -136,6 +136,7 @@ impl<T> WithMut<T> for core::sync::atomic::AtomicPtr<T> {
 /// structure be `'static`. If you wish to avoid that bound, you'll need to construct your own
 /// `Domain` for each instance of your data structure so that all the guarded data is reclaimed
 /// when your data structure is dropped.
+#[non_exhaustive]
 pub struct Domain<F> {
     hazptrs: HazPtrRecords,
     untagged: [RetiredList; NUM_SHARDS],

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -136,7 +136,6 @@ impl<T> WithMut<T> for core::sync::atomic::AtomicPtr<T> {
 /// structure be `'static`. If you wish to avoid that bound, you'll need to construct your own
 /// `Domain` for each instance of your data structure so that all the guarded data is reclaimed
 /// when your data structure is dropped.
-#[non_exhaustive]
 pub struct Domain<F> {
     hazptrs: HazPtrRecords,
     untagged: [RetiredList; NUM_SHARDS],

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -47,13 +47,13 @@ impl Global {
     }
 }
 
-/// Mark a [domain family](Domain) that unique caracterize a [domain instance](Domain)
+/// Marks a [domain family](Domain) that uniquely characterizes a [domain instance](Domain).
 ///
-/// See [`Global`] and [`unique_domain`]
+/// See [`Global`] and [`unique_domain`] for examples of families that safely manage this.
 ///
 /// # Safety
 ///
-/// Implementors of this trait must guarantee only one Domain of that family can be contructed.
+/// Implementors of this trait must guarantee only one Domain of the implementing family can ever be constructed.
 pub unsafe trait Singleton {}
 
 // Safety: we can guarantee that there's only ever one Domain<Global> because Global itself is not
@@ -166,7 +166,8 @@ impl Domain<Global> {
 }
 
 /// Generate a [`Domain`] with an entirely unique domain family.
-/// The generated family implements [`Singleton`],
+///
+/// The generated family implements [`Singleton`], which enables the use of [`AtomicPtr::safe_load`].
 #[macro_export]
 macro_rules! unique_domain {
     () => {{

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -56,7 +56,9 @@ impl Global {
 /// Implementors of this trait must guarantee only one Domain of that family can be contructed.
 pub unsafe trait Singleton {}
 
-// Safety: there are only one instance of Domain<Global>
+// Safety: we can guarantee that there's only ever one Domain<Global> because Global itself is not
+// possible to construct outside of this crate (due to #[non_exhaustive] + no public constructor),
+// and we only ever construct one Domain from it internally in the form of a single static.
 unsafe impl Singleton for Global {}
 
 #[cfg(not(loom))]
@@ -168,8 +170,7 @@ impl Domain<Global> {
 macro_rules! unique_domain {
     () => {{
         struct UniqueFamily;
-        // Safety: UniqueFamily is only visible inside this scope,
-        // therefore no other Domain of that family can be constructed.
+        // Safety: nowhere else can construct an instance of UniqueFamily to pass to Domain::new.
         unsafe impl Singleton for UniqueFamily {}
         Domain::new(&UniqueFamily)
     }};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,20 +388,17 @@ impl<T, F, P> AtomicPtr<T, F, P> {
     /// The guard ensures that the loaded `T` will remain valid for as long as you hold a reference
     /// to it.
     ///
-    /// This method is a safe alternative to [`AtomicPtr::load`] available to 
-    /// [`Domain::Singleton`](singleton families) since it is a singleton, and thus 
+    /// This method is a safe alternative to [`AtomicPtr::load`] available to
+    /// [`Domain::Singleton`](singleton families) since it is a singleton, and thus
     /// is guaranteed to fulfill the safety requirement of [`AtomicPtr::load`]
-    pub fn safe_load<'hp, 'd>(
-        &'_ self,
-        hp: &'hp mut HazardPointer<'d, F>,
-    ) -> Option<&'hp T>
+    pub fn safe_load<'hp, 'd>(&'_ self, hp: &'hp mut HazardPointer<'d, F>) -> Option<&'hp T>
     where
         T: 'hp,
         F: 'static,
         F: Singleton,
     {
-        // Safety: by the safify garanties of Domain::Singleton there is exactly one domain of 
-        // this family, we know that all calls to `load` that have returned this object must have been 
+        // Safety: by the safify garanties of Domain::Singleton there is exactly one domain of
+        // this family, we know that all calls to `load` that have returned this object must have been
         // using the same domain as we're retiring to.
         unsafe { self.load(hp) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,17 +391,18 @@ where
     /// The guard ensures that the loaded `T` will remain valid for as long as you hold a reference
     /// to it.
     ///
-    /// It's safe for domains with __singleton families__, because the
-    /// [`Domain::Singleton`](unsafety of the trait) guarantees that there is only ever one
-    /// instance of a Domain with a singleton family, and therefore loads and stores using such a
-    /// family must be using the same (single) instance of that domain.
+    /// This method is only available for domains with _singleton families_, because
+    /// implementations of the unsafe [`Domain::Singleton`] trait guarantee that there
+    /// is only ever one instance of a Domain with the family in question, which in turn
+    /// implies that loads and stores using such a family **must** be using the same
+    /// (single) instance of that domain.
     pub fn safe_load<'hp, 'd>(&'_ self, hp: &'hp mut HazardPointer<'d, F>) -> Option<&'hp T>
     where
         T: 'hp,
         F: 'static,
     {
         // Safety: by the safety guarantees of Domain::Singleton there is exactly one domain of
-        // this family, we know that all calls to `load` that have returned this object must
+        // this family, so we know that all calls to `load` that have returned this object must
         // have been using the same domain as we're retiring to.
         unsafe { self.load(hp) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,24 +382,27 @@ where
     }
 }
 
-impl<T, F, P> AtomicPtr<T, F, P> {
+impl<T, F, P> AtomicPtr<T, F, P>
+where
+    F: Singleton,
+{
     /// Loads the value from the stored pointer and guards it using the given hazard pointer.
     ///
     /// The guard ensures that the loaded `T` will remain valid for as long as you hold a reference
     /// to it.
     ///
-    /// This method is a safe alternative to [`AtomicPtr::load`] available to
-    /// [`Domain::Singleton`](singleton families) since it is a singleton, and thus
-    /// is guaranteed to fulfill the safety requirement of [`AtomicPtr::load`]
+    /// It's safe for domains with __singleton families__, because the
+    /// [`Domain::Singleton`](unsafety of the trait) guarantees that there is only ever one
+    /// instance of a Domain with a singleton family, and therefore loads and stores using such a
+    /// family must be using the same (single) instance of that domain.
     pub fn safe_load<'hp, 'd>(&'_ self, hp: &'hp mut HazardPointer<'d, F>) -> Option<&'hp T>
     where
         T: 'hp,
         F: 'static,
-        F: Singleton,
     {
-        // Safety: by the safify garanties of Domain::Singleton there is exactly one domain of
-        // this family, we know that all calls to `load` that have returned this object must have been
-        // using the same domain as we're retiring to.
+        // Safety: by the safety guarantees of Domain::Singleton there is exactly one domain of
+        // this family, we know that all calls to `load` that have returned this object must
+        // have been using the same domain as we're retiring to.
         unsafe { self.load(hp) }
     }
 }


### PR DESCRIPTION
Improve the ergonomic of domains generated by the macro `unique_domain` making the AtomicPtr::safe_load available