### PR TITLE
Fix broken documentation links

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -111,7 +111,7 @@ impl<T> WithMut<T> for core::sync::atomic::AtomicPtr<T> {
 ///
 /// This isn't bullet-proof though! Nothing prevents you from using hazard pointers allocated from
 /// one instance of `Domain<Family>` with an atomic pointer whose writers use a different
-/// _instance_ of `Domin<Family>`. So be careful!
+/// _instance_ of `Domain<Family>`. So be careful!
 ///
 /// The [`unique_domain`] macro provides a mechanism for constructing a domain with a unique
 /// domain family that cannot be confused with any other. If you can use it, you should do so, as

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -6,6 +6,9 @@ use alloc::collections::BTreeSet;
 use core::marker::PhantomData;
 use core::sync::atomic::Ordering;
 
+#[cfg(doc)]
+use crate::*;
+
 // Like folly's implementation, we use a time a based check to run reclamation about every
 // `SYNC_TIME_PERIOD` nanoseconds. The next time we should run reclamation is stored in
 // `due_time` inside `Domain`. On `no_std` we don't (yet) have access to time so this feature is
@@ -82,12 +85,12 @@ impl<T> WithMut<T> for core::sync::atomic::AtomicPtr<T> {
 
 /// Synchronization point between hazard pointers and the writers they guard against.
 ///
-/// Every [hazard pointer](crate::HazardPointer) is associated with a domain, and can only guard
+/// Every [hazard pointer](HazardPointer) is associated with a domain, and can only guard
 /// against reclamation of objects that are retired through that same domain. In other words, you
 /// should always ensure that your code uses the same domain to retire objects as it uses to make
 /// hazard pointers to read those objects. If it does not, the hazard pointers will provide no
 /// meaningful protection. This connection is part of the safety contract for
-/// [`HazardPointer::protect`](crate::HazardPointer::protect).
+/// [`HazardPointer::protect`].
 ///
 /// ## Domain families
 ///
@@ -105,9 +108,9 @@ impl<T> WithMut<T> for core::sync::atomic::AtomicPtr<T> {
 /// type AtomicPtr<T> = haphazard::AtomicPtr<T, Family>;
 /// ```
 ///
-/// This ensures at compile-time that you don't, for example, use a
-/// [`HazardPointer`](crate::HazardPointer) from the [global domain](Global) to guard loads from an
-/// [`AtomicPtr`](crate::AtomicPtr) that is tied to a custom domain.
+/// This ensures at compile-time that you don't, for example, use a [`HazardPointer`] from the
+/// [global domain](Global) to guard loads from an [`AtomicPtr`](crate::AtomicPtr) that is tied to
+/// a custom domain.
 ///
 /// This isn't bullet-proof though! Nothing prevents you from using hazard pointers allocated from
 /// one instance of `Domain<Family>` with an atomic pointer whose writers use a different
@@ -167,7 +170,7 @@ impl Domain<Global> {
 /// Generate a [`Domain`] with an entirely unique domain family.
 ///
 /// The generated family implements [`Singleton`], which enables the use of
-/// [`crate::AtomicPtr::safe_load`].
+/// [`AtomicPtr::safe_load`](crate::AtomicPtr::safe_load).
 #[macro_export]
 macro_rules! unique_domain {
     () => {{
@@ -420,7 +423,7 @@ impl<F> Domain<F> {
     ///
     /// # Safety
     ///
-    /// 1. No [`HazardPointer`](crate::HazardPointer) will guard `ptr` from this point forward.
+    /// 1. No [`HazardPointer`] will guard `ptr` from this point forward.
     /// 2. `ptr` has not already been retired unless it has been reclaimed since then.
     /// 3. `ptr` is valid as `&T` until `self` is dropped.
     pub unsafe fn retire_ptr<T, P>(&self, ptr: *mut T) -> usize

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -87,7 +87,7 @@ impl<T> WithMut<T> for core::sync::atomic::AtomicPtr<T> {
 /// should always ensure that your code uses the same domain to retire objects as it uses to make
 /// hazard pointers to read those objects. If it does not, the hazard pointers will provide no
 /// meaningful protection. This connection is part of the safety contract for
-/// [`HazardPointer::load`](HazardPointer::load).
+/// [`HazardPointer::protect`](crate::HazardPointer::protect).
 ///
 /// ## Domain families
 ///
@@ -166,7 +166,8 @@ impl Domain<Global> {
 
 /// Generate a [`Domain`] with an entirely unique domain family.
 ///
-/// The generated family implements [`Singleton`], which enables the use of [`AtomicPtr::safe_load`].
+/// The generated family implements [`Singleton`], which enables the use of
+/// [`crate::AtomicPtr::safe_load`].
 #[macro_export]
 macro_rules! unique_domain {
     () => {{
@@ -419,7 +420,7 @@ impl<F> Domain<F> {
     ///
     /// # Safety
     ///
-    /// 1. no [`HazardPointer`] will guard `ptr` from this point forward.
+    /// 1. No [`HazardPointer`](crate::HazardPointer) will guard `ptr` from this point forward.
     /// 2. `ptr` has not already been retired unless it has been reclaimed since then.
     /// 3. `ptr` is valid as `&T` until `self` is dropped.
     pub unsafe fn retire_ptr<T, P>(&self, ptr: *mut T) -> usize

--- a/src/hazard.rs
+++ b/src/hazard.rs
@@ -20,7 +20,7 @@ use core::sync::atomic::Ordering;
 /// `F` is a _domain family_, which helps enforce that statically. Families are discussed in the
 /// documentation for [`Domain`]. `F` defaults to the [global domain](crate::Global).
 ///
-/// If you want a (slightly) higher-level interface, use [`haphazard::AtomicPtr`].
+/// If you want a (slightly) higher-level interface, use [`AtomicPtr`].
 ///
 /// If you need to protect multiple referenced objects at the same time, use
 /// [`HazardPointerArray`].
@@ -81,8 +81,8 @@ impl<'domain, F> HazardPointer<'domain, F> {
     /// # Safety
     ///
     /// 1. The value loaded from `AtomicPtr` is a valid `&T`, or null.
-    /// 2. The loaded `&T` will only be deallocated through calls to [`HazPtrObject::retire`] on
-    ///    the same [`Domain`] as this holder is associated with.
+    /// 2. The loaded `&T` will only be deallocated through calls to `retire` functions on the same
+    ///    [`Domain`] as this holder is associated with.
     pub unsafe fn protect<'l, T>(&'l mut self, src: &'_ AtomicPtr<T>) -> Option<&'l T>
     where
         F: 'static,
@@ -155,8 +155,8 @@ impl<'domain, F> HazardPointer<'domain, F> {
     /// # Safety
     ///
     /// 1. The value loaded from `AtomicPtr` is a valid `&T`, or null.
-    /// 2. The loaded `&T` will only be deallocated through calls to [`HazPtrObject::retire`] on
-    ///    the same [`Domain`] as this holder is associated with.
+    /// 2. The loaded `&T` will only be deallocated through calls to `retire` functions on the same
+    ///    [`Domain`] as this holder is associated with.
     pub unsafe fn try_protect<'l, T>(
         &'l mut self,
         ptr: *mut T,
@@ -262,8 +262,8 @@ impl<F> Drop for HazardPointer<'_, F> {
 /// let _ = HazardPointer::many_in_domain::<4>(haphazard::Domain::global());
 /// ```
 ///
-/// To use the individual hazard pointers, use [`HazardPointerArray::pointers`], or protect
-/// multiple [`AtomicPtr`]s using [`HazardPointerArray::protect_all`].
+/// To use the individual hazard pointers, use [`HazardPointerArray::as_refs`], or protect multiple
+/// [`AtomicPtr`]s using [`HazardPointerArray::protect_all`].
 pub struct HazardPointerArray<'domain, F, const N: usize> {
     // ManuallyDrop is required to prevent the HazardPointer from reclaiming itself, since
     // HazardPointerArray has it's own drop implementation with an optimized reclaim for all hazard
@@ -314,8 +314,8 @@ impl<'domain, F, const N: usize> HazardPointerArray<'domain, F, N> {
     /// # Safety
     ///
     /// 1. The values loaded each `AtomicPtr` are all valid `&T`, or null.
-    /// 2. The loaded `&T`s will only be deallocated through calls to [`HazPtrObject::retire`] on
-    ///    the same [`Domain`] as this holder array is associated with.
+    /// 2. The loaded `&T` will only be deallocated through calls to `retire` functions on the same
+    ///    [`Domain`] as this holder is associated with.
     pub unsafe fn protect_all<'l, T>(
         &'l mut self,
         mut sources: [&'_ AtomicPtr<T>; N],

--- a/src/hazard.rs
+++ b/src/hazard.rs
@@ -5,6 +5,9 @@ use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
+#[cfg(doc)]
+use crate::*;
+
 /// A type that can protect a referenced object from reclamation.
 ///
 /// Protects up to a single address from concurrent reclamation in the referenced [`Domain`].
@@ -18,7 +21,7 @@ use core::sync::atomic::Ordering;
 /// Note that a hazard pointer can only protect an object if any call to `retire` for said object
 /// happens in the same domain as the one the hazard pointer was created in. The generic argument
 /// `F` is a _domain family_, which helps enforce that statically. Families are discussed in the
-/// documentation for [`Domain`]. `F` defaults to the [global domain](crate::Global).
+/// documentation for [`Domain`]. `F` defaults to the [global domain](Global).
 ///
 /// If you want a (slightly) higher-level interface, use [`AtomicPtr`].
 ///
@@ -36,12 +39,12 @@ impl Default for HazardPointer<'static, crate::Global> {
 }
 
 impl HazardPointer<'static, crate::Global> {
-    /// Create a new hazard pointer in the [global domain](crate::Global).
+    /// Create a new hazard pointer in the [global domain](Global).
     pub fn new() -> Self {
         HazardPointer::new_in_domain(Domain::global())
     }
 
-    /// Create a new hazard pointer array in the [global domain](crate::Global).
+    /// Create a new hazard pointer array in the [global domain](Global).
     pub fn many<const N: usize>() -> HazardPointerArray<'static, crate::Global, N> {
         HazardPointer::many_in_domain(Domain::global())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,13 +184,19 @@ pub use hazard::{HazardPointer, HazardPointerArray};
 
 /// A managed pointer type which can be safely shared between threads.
 ///
-/// Unlike [`std::sync::AtomicPtr`](core::sync::AtomicPtr), `haphazard::AtomicPtr` can safely load
-/// `&T` directly, and ensure that the referenced `T` is not deallocated until the `&T` is dropped,
-/// even in the presence of concurrent writers. Also unlike
-/// [`std::sync::AtomicPtr`](core::sync::AtomicPtr), **all loads and stores on this type use
-/// `Acquire` and `Release` semantics**.
+/// This type has the same in-memory representation as a [`std::sync::atomic::AtomicPtr`], but
+/// provides additional functionality and stricter guarantees:
 ///
-/// To construct one, use `AtomicPtr::from`:
+/// - `haphazard::AtomicPtr` can safely load `&T` directly, and ensure that the referenced `T` is
+///   not deallocated until the `&T` is dropped, even in the presence of concurrent writers.
+/// - All loads and stores on this type use `Acquire` and `Release` semantics.
+///
+/// **Note:** This type is only available on platforms that support atomic loads and stores of
+/// pointers. Its size depends on the target pointer’s size.
+///
+/// # Basic usage
+///
+/// To construct one, use [`AtomicPtr::from`]:
 ///
 /// ```rust
 /// # use haphazard::AtomicPtr;
@@ -208,15 +214,9 @@ pub use hazard::{HazardPointer, HazardPointerArray};
 /// used to ensure that when writers drop a value, it is dropped using the appropriate `Drop`
 /// implementation.
 ///
-/// This type has the same in-memory representation as a
-/// [`std::sync::AtomicPtr`](core::sync::AtomicPtr).
-///
 /// **Warning:** When this type is dropped, it does _not_ automatically retire the object it is
 /// currently pointing to. In order to retire (and eventually reclaim) that object, use
-/// [`AtomicPtr::retire_in`].
-///
-/// **Note:** This type is only available on platforms that support atomic loads and stores of
-/// pointers. Its size depends on the target pointer’s size.
+/// [`AtomicPtr::retire`] or [`AtomicPtr::retire_in`].
 ///
 // The unsafe constract enforced throughout this crate is that a given `AtomicPtr<T, F, P>` only
 // ever holds the address of a valid `T` allocated through `P` from a domain with family `F`, or
@@ -392,18 +392,17 @@ where
     /// to it.
     ///
     /// This method is only available for domains with _singleton families_, because
-    /// implementations of the unsafe [`Domain::Singleton`] trait guarantee that there
-    /// is only ever one instance of a Domain with the family in question, which in turn
-    /// implies that loads and stores using such a family **must** be using the same
-    /// (single) instance of that domain.
+    /// implementations of the unsafe [`Singleton`] trait guarantee that there is only ever one
+    /// instance of a [`Domain`] with the family in question, which in turn implies that loads and
+    /// stores using such a family **must** be using the same (single) instance of that domain.
     pub fn safe_load<'hp, 'd>(&'_ self, hp: &'hp mut HazardPointer<'d, F>) -> Option<&'hp T>
     where
         T: 'hp,
         F: 'static,
     {
-        // Safety: by the safety guarantees of Domain::Singleton there is exactly one domain of
-        // this family, so we know that all calls to `load` that have returned this object must
-        // have been using the same domain as we're retiring to.
+        // Safety: by the safety guarantees of Singleton there is exactly one domain of this
+        // family, so we know that all calls to `load` that have returned this object must have
+        // been using the same domain as we're retiring to.
         unsafe { self.load(hp) }
     }
 }
@@ -590,7 +589,7 @@ impl<T, F, P> AtomicPtr<T, F, P> {
     ///
     /// # Safety
     ///
-    /// `ptr must conform to the same safety requirements as the argument to [`AtomicPtr::new`].
+    /// `ptr` must conform to the same safety requirements as the argument to [`AtomicPtr::new`].
     pub unsafe fn store_ptr(&self, ptr: *mut T) {
         self.0.store(ptr, Ordering::Release)
     }
@@ -599,7 +598,7 @@ impl<T, F, P> AtomicPtr<T, F, P> {
     ///
     /// # Safety
     ///
-    /// `ptr must conform to the same safety requirements as the argument to [`AtomicPtr::new`].
+    /// `ptr` must conform to the same safety requirements as the argument to [`AtomicPtr::new`].
     pub unsafe fn swap_ptr(&self, ptr: *mut T) -> Option<Replaced<T, F, P>> {
         let ptr = self.0.swap(ptr, Ordering::Release);
         NonNull::new(ptr).map(|ptr| Replaced {
@@ -616,7 +615,7 @@ impl<T, F, P> AtomicPtr<T, F, P> {
     ///
     /// # Safety
     ///
-    /// `ptr must conform to the same safety requirements as the argument to [`AtomicPtr::new`].
+    /// `ptr` must conform to the same safety requirements as the argument to [`AtomicPtr::new`].
     pub unsafe fn compare_exchange_ptr(
         &self,
         current: *mut T,
@@ -641,7 +640,7 @@ impl<T, F, P> AtomicPtr<T, F, P> {
     ///
     /// # Safety
     ///
-    /// `ptr must conform to the same safety requirements as the argument to [`AtomicPtr::new`].
+    /// `ptr` must conform to the same safety requirements as the argument to [`AtomicPtr::new`].
     pub unsafe fn compare_exchange_weak_ptr(
         &self,
         current: *mut T,

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -8,8 +8,8 @@ use alloc::boxed::Box;
 /// type is `Drop`. This trait is effectively the same as `Drop` (every trait implies `Drop`), and
 /// has a blanket implementation for any type, so can be used instead of `dyn Drop`.
 ///
-/// See also https://github.com/rust-lang/rust/issues/86653 and
-/// https://github.com/rust-lang/rust/pull/86747.
+/// See also <https://github.com/rust-lang/rust/issues/86653> and
+/// <https://github.com/rust-lang/rust/pull/86747>.
 pub trait Reclaim {}
 impl<T> Reclaim for T {}
 


### PR DESCRIPTION
Also
- reorganised the intro to `AtomicPtr` for less repetition, and to separate the usage guidance,
- some formatting.