### PR TITLE
Fix AtomicPtr implementing Send and Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,10 @@ where
     }
 }
 
+unsafe impl<T, F, P> Send for AtomicPtr<T, F, P> {}
+
+unsafe impl<T, F, P> Sync for AtomicPtr<T, F, P> {}
+
 impl<T, F, P> AtomicPtr<T, F, P> {
     /// Directly construct an `AtomicPtr` from a raw pointer.
     ///


### PR DESCRIPTION
This is a very small fix that enables `Send` and `Sync` autotrait deduction for `haphazard::AtomicPtr`. The only issue before was using a raw pointer (`*mut`) would cause autodeduction of `!Send` and `!Sync`.  

You can also `unsafe impl` both `Send` and `Sync`, but this seems cleaner.

Closes #30 