### PR TITLE
Add simple Debug implementation to AtomicPtr that delegates to std::sync::atomic::AtomicPtr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ unsafe impl<T, F, P> Send for AtomicPtr<T, F, P> {}
 // (and thus may take ownership of one) ensure that `T: Send`.
 unsafe impl<T, F, P> Sync for AtomicPtr<T, F, P> {}
 
+#[cfg(all(not(loom), feature = "std"))]
 impl<T, F, P> std::fmt::Debug for AtomicPtr<T, F, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,9 +252,9 @@ unsafe impl<T, F, P> Send for AtomicPtr<T, F, P> {}
 // (and thus may take ownership of one) ensure that `T: Send`.
 unsafe impl<T, F, P> Sync for AtomicPtr<T, F, P> {}
 
-#[cfg(all(not(loom), feature = "std"))]
-impl<T, F, P> std::fmt::Debug for AtomicPtr<T, F, P> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+#[cfg(not(loom))]
+impl<T, F, P> core::fmt::Debug for AtomicPtr<T, F, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,12 @@ unsafe impl<T, F, P> Send for AtomicPtr<T, F, P> {}
 // (and thus may take ownership of one) ensure that `T: Send`.
 unsafe impl<T, F, P> Sync for AtomicPtr<T, F, P> {}
 
+impl<T, F, P> std::fmt::Debug for AtomicPtr<T, F, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl<T, F, P> From<P> for AtomicPtr<T, F, P>
 where
     P: raw::Pointer<T>,


### PR DESCRIPTION
For my use case, I wrapped `haphazard::AtomicPtr` in `std::sync::Arc` to enable shared ownership of the `AtomicPtr` across tasks. 

I then wanted to use `Arc::try_unwrap` and `Result::unwrap` when I can guarantee there is only one remaining refcount to cleanup that last `AtomicPtr` reference. 

`Result::unwrap` has that `Debug` requirement, so I thought it would make things easier if `haphazard::AtomicPtr` had a sane `Debug` implementation. This proposal just defers to the `std::atomic::AtomicPtr` `Debug` implementation.

Let me know if this looks good or you have some other idea for what `Debug` should output.