### PR TITLE
Make benchmarks compile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: --all-features --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ loom = "0.5.5"
 [dev-dependencies]
 criterion = "0.3"
 
+[lib]
+bench = false
+
 [[bench]]
 name = "folly"
 harness = false

--- a/benches/folly.rs
+++ b/benches/folly.rs
@@ -44,11 +44,11 @@ macro_rules! folly_bench {
 }
 
 folly_bench!(concurrent_new_holder, {
-    black_box(HazardPointer::make_global());
+    black_box(HazardPointer::new());
 });
 folly_bench!(concurrent_retire, {
-    let foo = Box::into_raw(Box::new(HazPtrObjectWrapper::with_global_domain(0)));
-    black_box(unsafe { HazPtrObjectWrapper::retire(foo, &deleters::drop_box) });
+    let foo: AtomicPtr<i32> = AtomicPtr::from(Box::new(0));
+    unsafe { foo.retire() };
 });
 
 criterion_group!(benches, concurrent_new_holder, concurrent_retire);

--- a/benches/folly.rs
+++ b/benches/folly.rs
@@ -47,8 +47,8 @@ folly_bench!(concurrent_new_holder, {
     black_box(HazardPointer::new());
 });
 folly_bench!(concurrent_retire, {
-    let foo: AtomicPtr<i32> = AtomicPtr::from(Box::new(0));
-    unsafe { foo.retire() };
+    let foo: AtomicPtr<i32> = black_box(AtomicPtr::from(Box::new(0)));
+    black_box(unsafe { foo.retire() });
 });
 
 criterion_group!(benches, concurrent_new_holder, concurrent_retire);


### PR DESCRIPTION
Additionally, add `--all-targets` to the github `cargo test` workflow, to keep benchmarks compiling.