### PR TITLE
Fix unsoundsess bug in `AtomicPtr::compare_exchange_*`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["std"]
 loom = "0.5.5"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3.1"
 
 [lib]
 bench = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,7 +606,6 @@ where
     ///
     /// Unlike [`AtomicPtr::compare_exchange`], this function is allowed to spuriously fail even
     /// when the comparison succeeds, which can result in more efficient code on some platforms.
-    ///
     /// The return value is a result indicating whether the new value was written and containing
     /// the previous value. On success this value is guaranteed to be equal to `current`.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -665,8 +664,8 @@ impl<T, F, P> AtomicPtr<T, F, P> {
 
     /// Stores `new` if the current pointer is `current`.
     ///
-    /// The return value is a result indicating whether the new value was written and containing
-    /// the previous value. On success this value is guaranteed to be equal to `current`.
+    /// The return value is a result indicating whether the new pointer was written and containing
+    /// the previous pointer. On success this value is guaranteed to be equal to `current`.
     ///
     /// # Safety
     ///
@@ -692,7 +691,7 @@ impl<T, F, P> AtomicPtr<T, F, P> {
     /// when the comparison succeeds, which can result in more efficient code on some platforms.
     ///
     /// The return value is a result indicating whether the new pointer was written and containing
-    /// the previous pointer.
+    /// the previous pointer. On success this value is guaranteed to be equal to `current`.
     ///
     /// # Safety
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,10 +576,6 @@ where
     ///
     /// The return value is a result indicating whether the new value was written and containing
     /// the previous value. On success this value is guaranteed to be equal to `current`.
-    ///
-    /// The return value is a result indicating whether the new value was written successfully.
-    /// - On success the result contains the pointer previously in `self`, or None if it was null
-    /// - On failure the result gives back `new`
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn compare_exchange(
         &self,
@@ -611,9 +607,8 @@ where
     /// Unlike [`AtomicPtr::compare_exchange`], this function is allowed to spuriously fail even
     /// when the comparison succeeds, which can result in more efficient code on some platforms.
     ///
-    /// The return value is a result indicating whether the new value was written successfully.
-    /// - On success the result contains the pointer previously in `self`, or None if it was null
-    /// - On failure the result gives back `new`
+    /// The return value is a result indicating whether the new value was written and containing
+    /// the previous value. On success this value is guaranteed to be equal to `current`.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn compare_exchange_weak(
         &self,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -216,9 +216,8 @@ struct Family;
 
 #[test]
 fn hazardptr_compare_exchange_fail() {
-    use haphazard::AtomicPtr as HpAtomicPtr;
     // SAFETY: p is null
-    let ptr: HpAtomicPtr<u32, Family> = unsafe { HpAtomicPtr::new(std::ptr::null_mut()) };
+    let ptr: haphazard::AtomicPtr<u32, Family> = unsafe { haphazard::AtomicPtr::new(std::ptr::null_mut()) };
 
     let not_current = Box::into_raw(Box::new(0u32));
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -217,7 +217,8 @@ struct Family;
 #[test]
 fn hazardptr_compare_exchange_fail() {
     // SAFETY: p is null
-    let ptr: haphazard::AtomicPtr<u32, Family> = unsafe { haphazard::AtomicPtr::new(std::ptr::null_mut()) };
+    let ptr: haphazard::AtomicPtr<u32, Family> =
+        unsafe { haphazard::AtomicPtr::new(std::ptr::null_mut()) };
 
     let not_current = Box::into_raw(Box::new(0u32));
 


### PR DESCRIPTION
Implements #36 and adds a test to check for its correctness.

EDIT: The following is all wrong. Thanks @Dr-Emann

~~There could be another very subtle issue with the `compare_exchange_weak` variant and our Pointer trait.~~

With `compare_exchange` (strong) the outcome is binary:
a. The swap succeeded so `new` is now stored into (and owned exclusively) by the data structure
b. The swap failed, and the caller gets ownership of `new` back

With `compare_exchange_weak`, this gets a bit muddy:
a. The swap succeeded, this is reported back successfully so `new` is now stored into (and owned exclusively) by the data structure -- easy

b. The swap failed, this is reported successfully, the caller gets ownership of `new` back -- easy

c. The swap actually succeeded, but the inner call to `std::sync::atomic::AtomicPtr::compare_exchange_weak` spuriously fails:
    Imagine the following happens:
    0. The failure path runs, and `Box::from_raw` is called on `new` which is now, actually, in the datastructure
    1. The calling thread is now preempted by the OS for a while
    2. A different thread swaps `new` out of the `AtomicPtr` and naively retires it because its _no longer accessible_ right?
    3. There are no active hazard pointers to it currently, so it is dropped immediately 
    4. The original thread comes alive again, holding a nuclear potato, a Box that think it owns freed memory


To be more rigorous, I believe the break in the safety chain that allows this is here:
https://github.com/jonhoo/haphazard/blob/e0e18f60f78652a63aba235be854f87d106c1a1b/src/lib.rs#L612-L616

Because `new` may be shared if the exchange spuriously failed.

Also this may not be a problem for `haphazard`, as the `haphazard::AtomicPtr` docs state:
https://github.com/jonhoo/haphazard/blob/e0e18f60f78652a63aba235be854f87d106c1a1b/src/lib.rs#L227-L229

But its a nice assumption to make when creating a data structure, because if the `haphazard::AtomicPtr` buckets in your concurrent hashmap don't own their pointees, who does?

I think we can fix this by simply checking if `compare_exchange_weak_ptr` failed but returned `current`.

Some questions:
1. Is this correct for the semantics of std's `AtomicPtr::compare_exchange_weak`?
2. If we do this check for spurious failure doesn't the semantics of `compare_exchange_weak` become the same as `compare_exchange` for callers (we catch spurious failures now)?

