### PR TITLE
Add `retire_ptr_with` method on `Domain`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "haphazard"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -433,18 +433,13 @@ impl<F> Domain<F> {
         T: Send,
         P: Pointer<T>,
     {
-        // First, stick ptr onto the list of retired objects.
-        //
-        // Safety: ptr will not be accessed after Domain is dropped, which is when 'domain ends.
-        let retired = Box::new(unsafe {
-            Retired::new(self, ptr, |ptr: *mut dyn Reclaim| {
+        unsafe {
+            self.retire_ptr_with(ptr, |ptr: *mut dyn Reclaim| {
                 // Safety: the safety requirements of `from_raw` are the same as the ones to call
                 // the deleter.
                 let _ = P::from_raw(ptr as *mut T);
             })
-        });
-
-        self.push_list(retired)
+        }
     }
 
     /// Retire `ptr`, and reclaim it once it is safe to do so.


### PR DESCRIPTION
After using the crate for a bit, which has been a very nice and ergonomic experience so far, I ran across something that posed and issue for me.

Given the current signature of `HarzardPointer`'s `protect` method,
```rust
pub unsafe fn protect<'l, T>(&'l mut self, src: &'_ AtomicPtr<T>) -> Option<&'l T>
    where
        T: Sync,
        F: 'static,
```
you are able to protect pointers, even if for all P besides  `Box<T>`, `P: !Pointer<T>`. That means you are able to safeguard
your pointers freely. Yet, when it comes to retiring your pointers with `retire_ptr`, the signature is:
```rust
pub unsafe fn retire_ptr<T, P>(&self, ptr: *mut T) -> usize
  where
      T: Send,
      P: Pointer<T>,
```

There is, of course, a chance that I am not using the crate correctly, which is also very much possible haha!

The problem for me is that my `T` is technically dynamically sized and needs it's own special deallocation function to be dropped. To make this work I thought adding a `retire_ptr_with` method with the following signature would work:
```rust
    pub unsafe fn retire_ptr_with<T>(
        &self,
        ptr: *mut T,
        deleter: unsafe fn(ptr: *mut dyn Reclaim),
    ) -> usize
    where
        T: Send,
```
Here `deleter` is a function that manually deallocates the value behind `*mut T`. In terms of ergonomics this seems quite nice, at least for my purposes.

Of course this may be a breaking change that would impact the API of the crate and thus I do understand if adding this would entail more than just a simple pull request!