### PR TITLE
Static Unique Domains

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -301,7 +301,7 @@ macro_rules! new {
         /// _family_ (the type `F`) with an object protected by a domain in a different family.
         /// However, it does _not_ protect you from mixing up domains with the same family type.
         /// Therefore, prefer creating domains with [`unique_domain`] or [`static_unique_domain`] where
-        /// possible, since type guarantee a unique `F` for every domain.
+        /// possible, since they guarantee a unique `F` for every domain.
         ///
         /// See the [`Domain`] documentation for more details.
         pub $($decl)*(_: &'_ F) -> Self {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -220,18 +220,17 @@ macro_rules! unique_domain {
 /// ```
 #[macro_export]
 macro_rules! static_unique_domain {
-    (static $domain:ident: Domain<$family:ident>) => {
-        use $crate::{Domain, Singleton};
+    ($v:vis static $domain:ident: Domain<$family:ident>) => {
         struct UniqueFamily;
         // Safety: nowhere else can construct an instance of UniqueFamily to pass to Domain::new.
-        unsafe impl Singleton for UniqueFamily {}
-        struct $family {
+        unsafe impl $crate::Singleton for UniqueFamily {}
+        $v struct $family {
             _inner: UniqueFamily,
         }
         // Safety: $family can only be constructed by first constructing an instance of
         // UniqueFamily, which is itself a Singlton.
-        unsafe impl Singleton for $family {}
-        static $domain: Domain<$family> = Domain::new(&$family {
+        unsafe impl $crate::Singleton for $family {}
+        $v static $domain: $crate::Domain<$family> = $crate::Domain::new(&$family {
             _inner: UniqueFamily,
         });
     };

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -190,7 +190,7 @@ macro_rules! unique_domain {
 
 /// Generate a static [`Domain`] with an entirely unique domain family.
 ///
-/// Usage: `unique_domain_family!(static DOMAIN: Domain<Family>);`
+/// Usage: `static_unique_domain!(static DOMAIN: Domain<Family>);`
 ///
 /// This macro is useful when you want to store a domain in a static variable, and makes it
 /// possible to name the Domain. The generated family implements [`Singleton`], which enables
@@ -218,6 +218,15 @@ macro_rules! unique_domain {
 /// }
 /// # fn main() {}
 /// ```
+///
+/// # Notes
+///
+/// This macro cannot be used in a function scope or impl block. This macro (at least currently)
+/// requires the ability to define a module, and therefore must be placed in module scope. This
+/// may be relaxed in the future, but hopefully shouldn't be exteneded.
+///
+/// This also restricts the ability to define a struct or module with the same name as the static
+/// variable, or the family.
 #[macro_export]
 macro_rules! static_unique_domain {
     ($v:vis static $domain:ident: Domain<$family:ident>) => {
@@ -227,6 +236,8 @@ macro_rules! static_unique_domain {
             // Safety: nowhere else can construct an instance of UniqueFamily to pass to Domain::new.
             unsafe impl $crate::Singleton for UniqueFamily {}
             pub struct $family {
+                // Technically, since we are in an inner module, this private member may actually
+                // be enough, it might not need to be a private type.
                 _inner: UniqueFamily,
             }
             // Safety: $family can only be constructed by first constructing an instance of
@@ -241,7 +252,9 @@ macro_rules! static_unique_domain {
     };
 }
 
-/// This item is defined purely to run compile_fail doc tests. It is marked as doc(hidden)
+/// This item is defined purely to run compile_fail doc tests. It is marked as `doc(hidden)`, to
+/// avoid polluting the documentation.
+///
 /// ```rust,compile_fail
 /// # struct DataStructure;
 /// # use haphazard::{HazardPointer, AtomicPtr, static_unique_domain};


### PR DESCRIPTION
Resolves: #46

Implements a new macro for static unique domains, which declare a static domain, with a nameable singleton family. I included a doc-test with an example usage, and I think I modified the documentation everywhere `unique_domain` is mentioned to also mention `static_unique_domain`.