### PR TITLE
Fix `unique_domain!` macro to avoid leaking singleton type

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -913,6 +913,15 @@ struct CannotConfuseGlobalReader;
 #[cfg(doctest)]
 struct CannotConfuseAcrossFamilies;
 
+/// Ensures the inner type (`UniqueFamily`) defined by unique_domain!() is not namable.
+/// ```compile_fail
+/// use haphazard::*;
+/// let dw = unique_domain!();
+/// let bad_dw = Domain::new(&UniqueFamily);
+/// ```
+#[cfg(doctest)]
+struct CannotNameInnerType;
+
 #[cfg(test)]
 mod tests {
     use super::Domain;

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -929,6 +929,7 @@ mod tests {
 
     #[test]
     fn create_multiple_unique_domains() {
+        use crate::Singleton;
         let domain_1 = unique_domain!();
         let domain_2 = unique_domain!();
     }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -928,6 +928,12 @@ mod tests {
     use core::{ptr::null_mut, sync::atomic::Ordering};
 
     #[test]
+    fn create_multiple_unique_domains() {
+        let domain_1 = unique_domain!();
+        let domain_2 = unique_domain!();
+    }
+
+    #[test]
     fn acquire_many_skips_used_nodes() {
         let domain = Domain::new(&());
         let rec1 = domain.acquire();

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -174,10 +174,13 @@ impl Domain<Global> {
 #[macro_export]
 macro_rules! unique_domain {
     () => {{
-        struct UniqueFamily;
-        // Safety: nowhere else can construct an instance of UniqueFamily to pass to Domain::new.
-        unsafe impl Singleton for UniqueFamily {}
-        Domain::new(&UniqueFamily)
+        fn create_domain() -> Domain<impl Singleton> {
+            struct UniqueFamily;
+            // Safety: nowhere else can construct an instance of UniqueFamily to pass to Domain::new.
+            unsafe impl Singleton for UniqueFamily {}
+            Domain::new(&UniqueFamily)
+        }
+        create_domain()
     }};
 }
 


### PR DESCRIPTION
Previously identified as a result of work on #47, the `UniqueFamily` Singleton
type is leaked by the `unique_domain!` macro. (See this playground for an
example)[https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=4cbb503bffe2921fb9f9adf9331839c8]

The original implementation used a lambda expression to generate a unique type,
but this was dropped at some point. I suspect the current implementation was
created to enable the `Singleton` trait to be implemented on the generated type.
However, this also means that the inner type was accidentally leaked. This PR
fixes that by introducing a function scope to define the `UniqueFamily` type,
and returns a `Domain<impl Singleton>`.
